### PR TITLE
Elixir: use ets select instead of lookup loop

### DIFF
--- a/trexit/lib/trexit/gtfs.ex
+++ b/trexit/lib/trexit/gtfs.ex
@@ -14,7 +14,7 @@ defmodule Trexit.GTFS do
             "schedules" =>
               :ets.select(
                 :stop_times,
-                for(st_ix <- st_ixs, do: {{st_ix, :_}, [], [:"$_"]})
+                for(st_ix <- st_ixs, do: {{st_ix, :_, :_, :_, :_}, [], [:"$_"]})
               )
               |> Enum.map(fn {_st_ix, _trip_id, stop_id, arrival_time, departure_time} ->
                 %{

--- a/trexit/lib/trexit/gtfs.ex
+++ b/trexit/lib/trexit/gtfs.ex
@@ -1,28 +1,26 @@
 defmodule Trexit.GTFS do
-  alias Trexit.GTFS.StopTime
-  alias Trexit.GTFS.Trip
-
   def schedules_for_route(route_id) do
     case :ets.lookup(:trips_ix_by_route, route_id) do
       [{^route_id, trip_ixs}] ->
         Enum.map(trip_ixs, fn trip_ix ->
-          [{^trip_ix, %Trip{trip_id: trip_id, route_id: ^route_id, service_id: service_id}}] =
-            :ets.lookup(:trips, trip_ix)
+          [{_trip_ix, trip_id, _route_id, service_id}] = :ets.lookup(:trips, trip_ix)
 
-          [{^trip_id, st_ixs}] = :ets.lookup(:stop_times_ix_by_trip, trip_id)
+          [{_trip_id, st_ixs}] = :ets.lookup(:stop_times_ix_by_trip, trip_id)
 
           %{
             "trip_id" => trip_id,
             "service_id" => service_id,
             "route_id" => route_id,
             "schedules" =>
-              Enum.map(st_ixs, fn st_ix ->
-                [{^st_ix, %StopTime{} = stop_time}] = :ets.lookup(:stop_times, st_ix)
-
+              :ets.select(
+                :stop_times,
+                for(st_ix <- st_ixs, do: {{st_ix, :_}, [], [:"$_"]})
+              )
+              |> Enum.map(fn {_st_ix, _trip_id, stop_id, arrival_time, departure_time} ->
                 %{
-                  "stop_id" => stop_time.stop_id,
-                  "arrival_time" => stop_time.arrival,
-                  "departure_time" => stop_time.departure
+                  "stop_id" => stop_id,
+                  "arrival_time" => arrival_time,
+                  "departure_time" => departure_time
                 }
               end)
           }

--- a/trexit/lib/trexit/gtfs/loader.ex
+++ b/trexit/lib/trexit/gtfs/loader.ex
@@ -2,9 +2,6 @@ defmodule Trexit.GTFS.Loader do
   use GenServer
   require Logger
 
-  alias Trexit.GTFS.StopTime
-  alias Trexit.GTFS.Trip
-
   def start_link(_) do
     GenServer.start_link(__MODULE__, [])
   end
@@ -59,13 +56,7 @@ defmodule Trexit.GTFS.Loader do
 
       :ets.insert(
         :stop_times,
-        {i,
-         %StopTime{
-           trip_id: trip_id,
-           stop_id: stop_id,
-           arrival: arrival_time,
-           departure: departure_time
-         }}
+        {i, trip_id, stop_id, arrival_time, departure_time}
       )
     end)
   end
@@ -87,12 +78,12 @@ defmodule Trexit.GTFS.Loader do
 
       :ets.insert(
         :trips,
-        {i,
-         %Trip{
-           trip_id: trip_id,
-           route_id: route_id,
-           service_id: service_id
-         }}
+        {
+          i,
+          trip_id,
+          route_id,
+          service_id
+        }
       )
     end)
   end

--- a/trexit/lib/trexit/gtfs/stop_time.ex
+++ b/trexit/lib/trexit/gtfs/stop_time.ex
@@ -1,3 +1,0 @@
-defmodule Trexit.GTFS.StopTime do
-  defstruct [:trip_id, :stop_id, :arrival, :departure]
-end

--- a/trexit/lib/trexit/gtfs/trip.ex
+++ b/trexit/lib/trexit/gtfs/trip.ex
@@ -1,3 +1,0 @@
-defmodule Trexit.GTFS.Trip do
-  defstruct [:trip_id, :route_id, :service_id]
-end


### PR DESCRIPTION
Hey thanks for the cool comparison project, I love stuff like this.

This PR uses `:ets.select` and matchspecs to avoid doing `:ets.lookup` in a `Enum.map` loop. Basically getting rid of an N+1 style lookup.

I benchmarked this by waiting for the data to finish loading (as confirmed by curl) and then running the k6 commands as specified in the README, and results look like this for `loadTest.js`, which are pretty different from the results I was getting on the unchanged project:

```
at [ 16:26:27 ] ➜ k6 run -u 50 --duration 30s loadTest.js

          /\      |‾‾| /‾‾/   /‾‾/
     /\  /  \     |  |/  /   /  /
    /  \/    \    |     (   /   ‾‾\
   /          \   |  |\  \ |  (‾)  |
  / __________ \  |__| \__\ \_____/ .io

  execution: local
     script: loadTest.js
     output: -

  scenarios: (100.00%) 1 scenario, 50 max VUs, 1m0s max duration (incl. graceful stop):
           * default: 50 looping VUs for 30s (gracefulStop: 30s)


running (0m31.8s), 00/50 VUs, 371 complete and 0 interrupted iterations
default ✓ [======================================] 50 VUs  30s

     data_received..................: 1.8 GB 55 MB/s
     data_sent......................: 3.4 MB 109 kB/s
     http_req_blocked...............: avg=7.07µs  min=0s    med=1µs     max=11.06ms p(90)=3µs      p(95)=3µs
     http_req_connecting............: avg=1.86µs  min=0s    med=0s      max=1.92ms  p(90)=0s       p(95)=0s
     http_req_duration..............: avg=42.15ms min=116µs med=25.32ms max=417.4ms p(90)=103.19ms p(95)=135.44ms
       { expected_response:true }...: avg=42.15ms min=116µs med=25.32ms max=417.4ms p(90)=103.19ms p(95)=135.44ms
     http_req_failed................: 0.00%  ✓ 0           ✗ 36729
     http_req_receiving.............: avg=85.41µs min=5µs   med=57µs    max=17.33ms p(90)=144µs    p(95)=200µs
     http_req_sending...............: avg=16.71µs min=1µs   med=6µs     max=22.81ms p(90)=13µs     p(95)=17µs
     http_req_tls_handshaking.......: avg=0s      min=0s    med=0s      max=0s      p(90)=0s       p(95)=0s
     http_req_waiting...............: avg=42.05ms min=107µs med=25.2ms  max=416.7ms p(90)=103.09ms p(95)=135.3ms
     http_reqs......................: 36729  1155.153839/s
     iteration_duration.............: avg=4.17s   min=1.83s med=4.23s   max=5.99s   p(90)=5.18s    p(95)=5.3s
     iterations.....................: 371    11.668221/s
     vus............................: 26     min=26        max=50
```

I'm not exactly sure how to test the json results from the API (and this was a pretty quick change) so it's entirely possible I've just broken the API and this benchmark is total garbage, but maybe you can help me see if the results I'm getting are what you expect the endpoint to return. In any case thanks again, and maybe this is useful!
