### PR TITLE
elixir: use stream when loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ from the trip ID to a list of indices into the big stop time list.
 | -------- | --------- |
 | C#       | 732       |
 | Deno     | 3,033     |
-| Elixir   | 6,183     |
+| Elixir   | 3,270     |
 | Go       | 848       |
 | Rust     | 467       |
 | Scala    | 858       |

--- a/trexit/lib/trexit/gtfs/loader.ex
+++ b/trexit/lib/trexit/gtfs/loader.ex
@@ -46,7 +46,7 @@ defmodule Trexit.GTFS.Loader do
     # assert column order
     [["trip_id", "arrival_time", "departure_time", "stop_id" | _]] =
       "../MBTA_GTFS/stop_times.txt"
-      |> File.stream!(skip_headers: false)
+      |> File.stream!()
       |> NimbleCSV.RFC4180.parse_stream(skip_headers: false)
       |> Stream.take(1)
       |> Enum.to_list()

--- a/trexit/lib/trexit/gtfs/loader.ex
+++ b/trexit/lib/trexit/gtfs/loader.ex
@@ -43,15 +43,19 @@ defmodule Trexit.GTFS.Loader do
   end
 
   defp get_stop_times() do
-    [header | rest] =
-      "../MBTA_GTFS/stop_times.txt"
-      |> File.read!()
-      |> NimbleCSV.RFC4180.parse_string(skip_headers: false)
-
     # assert column order
-    ["trip_id", "arrival_time", "departure_time", "stop_id" | _] = header
+    [["trip_id", "arrival_time", "departure_time", "stop_id" | _]] =
+      "../MBTA_GTFS/stop_times.txt"
+      |> File.stream!(skip_headers: false)
+      |> NimbleCSV.RFC4180.parse_stream(skip_headers: false)
+      |> Stream.take(1)
+      |> Enum.to_list()
 
-    Enum.with_index(rest, fn [trip_id, arrival_time, departure_time, stop_id | _], i ->
+    "../MBTA_GTFS/stop_times.txt"
+    |> File.stream!()
+    |> NimbleCSV.RFC4180.parse_stream(skip_headers: true)
+    |> Stream.with_index()
+    |> Stream.each(fn {[trip_id, arrival_time, departure_time, stop_id | _], i} ->
       case :ets.lookup(:stop_times_ix_by_trip, trip_id) do
         [] -> :ets.insert(:stop_times_ix_by_trip, {trip_id, [i]})
         [{_, sts}] -> :ets.insert(:stop_times_ix_by_trip, {trip_id, [i | sts]})
@@ -68,18 +72,23 @@ defmodule Trexit.GTFS.Loader do
          }}
       )
     end)
+    |> Stream.run()
   end
 
   defp get_trips() do
-    [header | rest] =
-      "../MBTA_GTFS/trips.txt"
-      |> File.read!()
-      |> NimbleCSV.RFC4180.parse_string(skip_headers: false)
-
     # assert column order
-    ["route_id", "service_id", "trip_id" | _] = header
+    [["route_id", "service_id", "trip_id" | _]] =
+      "../MBTA_GTFS/trips.txt"
+      |> File.stream!(skip_headers: false)
+      |> NimbleCSV.RFC4180.parse_stream(skip_headers: false)
+      |> Stream.take(1)
+      |> Enum.to_list()
 
-    Enum.with_index(rest, fn [route_id, service_id, trip_id | _], i ->
+    "../MBTA_GTFS/trips.txt"
+    |> File.stream!()
+    |> NimbleCSV.RFC4180.parse_stream(skip_headers: true)
+    |> Stream.with_index()
+    |> Stream.each(fn {[route_id, service_id, trip_id | _], i} ->
       case :ets.lookup(:trips_ix_by_route, route_id) do
         [] -> :ets.insert(:trips_ix_by_route, {route_id, [i]})
         [{_, trips}] -> :ets.insert(:trips_ix_by_route, {route_id, [i | trips]})
@@ -95,5 +104,6 @@ defmodule Trexit.GTFS.Loader do
          }}
       )
     end)
+    |> Stream.run()
   end
 end

--- a/trexit/lib/trexit/gtfs/loader.ex
+++ b/trexit/lib/trexit/gtfs/loader.ex
@@ -79,7 +79,7 @@ defmodule Trexit.GTFS.Loader do
     # assert column order
     [["route_id", "service_id", "trip_id" | _]] =
       "../MBTA_GTFS/trips.txt"
-      |> File.stream!(skip_headers: false)
+      |> File.stream!()
       |> NimbleCSV.RFC4180.parse_stream(skip_headers: false)
       |> Stream.take(1)
       |> Enum.to_list()


### PR DESCRIPTION
Handling a large binary is what Elixir is not very good at. Instead of having a very large binary from the file, use smaller chunks by using stream.

Previous

```
[info] Parsed stop_times.txt in 19374.448 ms
[info] Parsed trips.txt in 912.065 ms
```

Now

```
[info] Parsed stop_times.txt in 6363.793 ms
[info] Parsed trips.txt in 604.793 ms
```