### PR TITLE
Elixir: Use `:persistent_term` instead of ETS

### DIFF
--- a/trexit/config/config.exs
+++ b/trexit/config/config.exs
@@ -37,8 +37,9 @@ config :esbuild,
   ]
 
 # Configures Elixir's Logger
+config :logger, level: :warning
+
 config :logger, :console,
-  level: :warn,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 

--- a/trexit/config/prod.exs
+++ b/trexit/config/prod.exs
@@ -12,7 +12,7 @@ import Config
 config :trexit, TrexitWeb.Endpoint, cache_static_manifest: "priv/static/cache_manifest.json"
 
 # Do not print debug messages in production
-config :logger, level: :info
+config :logger, level: :warning
 
 # ## SSL Support
 #

--- a/trexit/lib/trexit/gtfs.ex
+++ b/trexit/lib/trexit/gtfs.ex
@@ -1,24 +1,35 @@
 defmodule Trexit.GTFS do
+  @compile :inline_list_funcs
+
   def schedules_for_route(route_id) do
-    for %{trip_id: trip_id, service_id: service_id} <-
-          lookup_trips_by_route(route_id) do
-      %{
-        trip_id: trip_id,
-        service_id: service_id,
-        route_id: route_id,
-        schedules: schedules_for_trip(trip_id)
-      }
-    end
+    :lists.map(
+      fn %{trip_id: trip_id, service_id: service_id} ->
+        %{
+          trip_id: trip_id,
+          service_id: service_id,
+          route_id: route_id,
+          schedules: schedules_for_trip(trip_id)
+        }
+      end,
+      lookup_trips_by_route(route_id)
+    )
   end
 
   defp schedules_for_trip(trip_id) do
-    for stop_time <- lookup_stop_times_by_trip(trip_id) do
-      %{
-        stop_id: stop_time.stop_id,
-        arrival_time: stop_time.arrival,
-        departure_time: stop_time.departure
-      }
-    end
+    :lists.map(
+      fn %{
+           stop_id: stop_id,
+           arrival: arrival,
+           departure: departure
+         } ->
+        %{
+          stop_id: stop_id,
+          arrival_time: arrival,
+          departure_time: departure
+        }
+      end,
+      lookup_stop_times_by_trip(trip_id)
+    )
   end
 
   defp lookup_trips_by_route(route_id) do

--- a/trexit/lib/trexit/gtfs.ex
+++ b/trexit/lib/trexit/gtfs.ex
@@ -1,7 +1,4 @@
 defmodule Trexit.GTFS do
-  alias Trexit.GTFS.StopTime
-  alias Trexit.GTFS.Trip
-
   def schedules_for_route(route_id) do
     for %{trip_id: trip_id, service_id: service_id} <-
           lookup_trips_by_route(route_id) do

--- a/trexit/lib/trexit/gtfs.ex
+++ b/trexit/lib/trexit/gtfs.ex
@@ -3,33 +3,34 @@ defmodule Trexit.GTFS do
   alias Trexit.GTFS.Trip
 
   def schedules_for_route(route_id) do
-    case :ets.lookup(:trips_ix_by_route, route_id) do
-      [{^route_id, trip_ixs}] ->
-        Enum.map(trip_ixs, fn trip_ix ->
-          [{^trip_ix, %Trip{trip_id: trip_id, route_id: ^route_id, service_id: service_id}}] =
-            :ets.lookup(:trips, trip_ix)
-
-          [{^trip_id, st_ixs}] = :ets.lookup(:stop_times_ix_by_trip, trip_id)
-
-          %{
-            "trip_id" => trip_id,
-            "service_id" => service_id,
-            "route_id" => route_id,
-            "schedules" =>
-              Enum.map(st_ixs, fn st_ix ->
-                [{^st_ix, %StopTime{} = stop_time}] = :ets.lookup(:stop_times, st_ix)
-
-                %{
-                  "stop_id" => stop_time.stop_id,
-                  "arrival_time" => stop_time.arrival,
-                  "departure_time" => stop_time.departure
-                }
-              end)
-          }
-        end)
-
-      _ ->
-        []
+    for %{trip_id: trip_id, service_id: service_id} <-
+          lookup_trips_by_route(route_id) do
+      %{
+        trip_id: trip_id,
+        service_id: service_id,
+        route_id: route_id,
+        schedules: schedules_for_trip(trip_id)
+      }
     end
+  end
+
+  defp schedules_for_trip(trip_id) do
+    for stop_time <- lookup_stop_times_by_trip(trip_id) do
+      %{
+        stop_id: stop_time.stop_id,
+        arrival_time: stop_time.arrival,
+        departure_time: stop_time.departure
+      }
+    end
+  end
+
+  defp lookup_trips_by_route(route_id) do
+    :persistent_term.get({Trexit.GTFS, :trips_by_route})
+    |> Map.get(route_id, [])
+  end
+
+  defp lookup_stop_times_by_trip(trip_id) do
+    :persistent_term.get({Trexit.GTFS, :stop_times_by_trip})
+    |> Map.get(trip_id, [])
   end
 end

--- a/trexit/lib/trexit/gtfs/loader.ex
+++ b/trexit/lib/trexit/gtfs/loader.ex
@@ -22,24 +22,19 @@ defmodule Trexit.GTFS.Loader do
   end
 
   def load() do
-    :ets.new(:stop_times, [:named_table, {:read_concurrency, true}])
-    :ets.new(:stop_times_ix_by_trip, [:named_table, {:read_concurrency, true}])
-    :ets.new(:trips, [:named_table, {:read_concurrency, true}])
-    :ets.new(:trips_ix_by_route, [:named_table, {:read_concurrency, true}])
-
     {time, _} =
       :timer.tc(fn ->
         get_stop_times()
       end)
 
-    Logger.info("Parsed stop_times.txt in #{time / 1000} ms")
+    Logger.warning("Parsed stop_times.txt in #{time / 1000} ms")
 
     {time, _} =
       :timer.tc(fn ->
         get_trips()
       end)
 
-    Logger.info("Parsed trips.txt in #{time / 1000} ms")
+    Logger.warning("Parsed trips.txt in #{time / 1000} ms")
   end
 
   defp get_stop_times() do
@@ -51,23 +46,17 @@ defmodule Trexit.GTFS.Loader do
     # assert column order
     ["trip_id", "arrival_time", "departure_time", "stop_id" | _] = header
 
-    Enum.with_index(rest, fn [trip_id, arrival_time, departure_time, stop_id | _], i ->
-      case :ets.lookup(:stop_times_ix_by_trip, trip_id) do
-        [] -> :ets.insert(:stop_times_ix_by_trip, {trip_id, [i]})
-        [{_, sts}] -> :ets.insert(:stop_times_ix_by_trip, {trip_id, [i | sts]})
-      end
-
-      :ets.insert(
-        :stop_times,
-        {i,
-         %StopTime{
-           trip_id: trip_id,
-           stop_id: stop_id,
-           arrival: arrival_time,
-           departure: departure_time
-         }}
-      )
+    rest
+    |> Enum.map(fn [trip_id, arrival_time, departure_time, stop_id | _] ->
+      %StopTime{
+        trip_id: trip_id,
+        stop_id: stop_id,
+        arrival: arrival_time,
+        departure: departure_time
+      }
     end)
+    |> Enum.group_by(& &1.trip_id)
+    |> then(&:persistent_term.put({Trexit.GTFS, :stop_times_by_trip}, &1))
   end
 
   defp get_trips() do
@@ -79,21 +68,15 @@ defmodule Trexit.GTFS.Loader do
     # assert column order
     ["route_id", "service_id", "trip_id" | _] = header
 
-    Enum.with_index(rest, fn [route_id, service_id, trip_id | _], i ->
-      case :ets.lookup(:trips_ix_by_route, route_id) do
-        [] -> :ets.insert(:trips_ix_by_route, {route_id, [i]})
-        [{_, trips}] -> :ets.insert(:trips_ix_by_route, {route_id, [i | trips]})
-      end
-
-      :ets.insert(
-        :trips,
-        {i,
-         %Trip{
-           trip_id: trip_id,
-           route_id: route_id,
-           service_id: service_id
-         }}
-      )
+    rest
+    |> Enum.map(fn [route_id, service_id, trip_id | _] ->
+      %Trip{
+        trip_id: trip_id,
+        route_id: route_id,
+        service_id: service_id
+      }
     end)
+    |> Enum.group_by(& &1.route_id)
+    |> then(&:persistent_term.put({Trexit.GTFS, :trips_by_route}, &1))
   end
 end


### PR DESCRIPTION
Changes:

- Use `:persistent_term` for lookups instead of `:ets`
- Use ~~`for`~~ `:lists.map` instead of `Enum.map` when iterating over the result lists.
- Use atoms instead of small strings in the result maps.
- Less defensive pattern matching in places where we already know the shape of the result data.
- Properly configure the full logger to `:warning` level (rather than only the `:console` backend), ensuring that lower-level log output is not evaluated only to be discarded.

This PR should be fully compatible with #13 and #11.