### PR TITLE
Simplify Go code

### DIFF
--- a/trogsit/app.go
+++ b/trogsit/app.go
@@ -48,23 +48,24 @@ func buildTripResponse(
 	resp := make([]TripResponse, 0, len(tripIxs))
 	for tripIx := range tripIxs {
 		trip := trips[tripIx]
-		tripResponse := TripResponse{
-			TripID:    trip.TripID,
-			ServiceID: trip.ServiceID,
-			RouteID:   trip.RouteID,
-		}
 
 		stopTimeIxs := stopTimesIxByTrip[trip.TripID]
-		tripResponse.Schedules = make([]ScheduleResponse, 0, len(stopTimeIxs))
+		schedules := make([]ScheduleResponse, 0, len(stopTimeIxs))
 		for stopTimeIx := range stopTimeIxs {
 			stopTime := stopTimes[stopTimeIx]
-			tripResponse.Schedules = append(tripResponse.Schedules, ScheduleResponse{
+			schedules = append(schedules, ScheduleResponse{
 				StopID:    stopTime.StopID,
 				Arrival:   stopTime.Arrival,
 				Departure: stopTime.Departure,
 			})
 		}
-		resp = append(resp, tripResponse)
+
+		resp = append(resp, TripResponse{
+			TripID:    trip.TripID,
+			ServiceID: trip.ServiceID,
+			RouteID:   trip.RouteID,
+			Schedules: schedules,
+		})
 	}
 	return resp
 }

--- a/trogsit/app.go
+++ b/trogsit/app.go
@@ -44,38 +44,29 @@ func buildTripResponse(
 	trips []Trip,
 	tripsIxByRoute map[string][]int,
 ) []TripResponse {
-	tripIxs, ok := tripsIxByRoute[route]
-
-	if ok {
-		resp := make([]TripResponse, 0, len(tripIxs))
-		for tripIx := range tripIxs {
-			trip := trips[tripIx]
-			tripResponse := TripResponse{
-				TripID:    trip.TripID,
-				ServiceID: trip.ServiceID,
-				RouteID:   trip.RouteID,
-			}
-
-			stopTimeIxs, ok := stopTimesIxByTrip[trip.TripID]
-			if ok {
-				tripResponse.Schedules = make([]ScheduleResponse, 0, len(stopTimeIxs))
-				for stopTimeIx := range stopTimeIxs {
-					stopTime := stopTimes[stopTimeIx]
-					tripResponse.Schedules = append(tripResponse.Schedules, ScheduleResponse{
-						StopID:    stopTime.StopID,
-						Arrival:   stopTime.Arrival,
-						Departure: stopTime.Departure,
-					})
-				}
-			} else {
-				tripResponse.Schedules = []ScheduleResponse{}
-			}
-			resp = append(resp, tripResponse)
+	tripIxs := tripsIxByRoute[route]
+	resp := make([]TripResponse, 0, len(tripIxs))
+	for tripIx := range tripIxs {
+		trip := trips[tripIx]
+		tripResponse := TripResponse{
+			TripID:    trip.TripID,
+			ServiceID: trip.ServiceID,
+			RouteID:   trip.RouteID,
 		}
-		return resp
-	} else {
-		return []TripResponse{}
+
+		stopTimeIxs := stopTimesIxByTrip[trip.TripID]
+		tripResponse.Schedules = make([]ScheduleResponse, 0, len(stopTimeIxs))
+		for stopTimeIx := range stopTimeIxs {
+			stopTime := stopTimes[stopTimeIx]
+			tripResponse.Schedules = append(tripResponse.Schedules, ScheduleResponse{
+				StopID:    stopTime.StopID,
+				Arrival:   stopTime.Arrival,
+				Departure: stopTime.Departure,
+			})
+		}
+		resp = append(resp, tripResponse)
 	}
+	return resp
 }
 
 func main() {
@@ -124,12 +115,7 @@ func getStopTimes() ([]StopTime, map[string][]int) {
 	stsByTrip := make(map[string][]int)
 	for i, rec := range records[1:] {
 		trip := rec[0]
-		sts, ok := stsByTrip[trip]
-		if ok {
-			stsByTrip[trip] = append(sts, i)
-		} else {
-			stsByTrip[trip] = []int{i}
-		}
+		stsByTrip[trip] = append(stsByTrip[trip], i)
 		stopTimes = append(stopTimes, StopTime{TripID: trip, StopID: rec[3], Arrival: rec[1], Departure: rec[2]})
 	}
 	end := time.Now()
@@ -166,12 +152,7 @@ func getTrips() ([]Trip, map[string][]int) {
 	tripsByRoute := make(map[string][]int)
 	for i, rec := range records[1:] {
 		route := rec[0]
-		ts, ok := tripsByRoute[route]
-		if ok {
-			tripsByRoute[route] = append(ts, i)
-		} else {
-			tripsByRoute[route] = []int{i}
-		}
+		tripsByRoute[route] = append(tripsByRoute[route], i)
 		trips = append(trips, Trip{TripID: rec[2], RouteID: route, ServiceID: rec[1]})
 	}
 	end := time.Now()


### PR DESCRIPTION
I don't anticipate that this will affect the performance at all, but it will remove a lot of conditionals that appear redundant.

In Go, `append(x, someElement)`, where `x` is a `nil` slice, will create a new slice to contain `someElement`, it won't explode. Similarly, accessing a non-existent element of a `map` will return the zero value, which will be `nil` for a slice like `[]int`, it won't explode either. Iterating or checking the length of a `nil` slice will work fine too, it'll just be the equivalent of doing the same operations to an empty slice.

I haven't actually _tested_ this code because I didn't feel like setting up the whole environment, but I think it should work.

in my opinion, it's also more idiomatic to construct values once the fields are all known, which you were already doing sometimes, so I added a commit to do that in one other place.