### PR TITLE
Go perf

### DIFF
--- a/trogsit/app.go
+++ b/trogsit/app.go
@@ -57,13 +57,9 @@ func main() {
 		route := strings.Split(r.URL.Path, "/")[2]
 		resp := buildTripResponse(tripsByRoute[route], stopTimesByTrip)
 		w.Header().Set("Content-Type", "application/json")
-		json_resp, err := json.Marshal(resp)
-		if err != nil {
+
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			fmt.Println("json error", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("500 - Something bad happened!"))
-		} else {
-			w.Write(json_resp)
 		}
 	})
 	log.Fatal(http.ListenAndServe(":4000", nil))

--- a/trogsit/app.go
+++ b/trogsit/app.go
@@ -49,7 +49,7 @@ func buildTripResponse(
 	tripIxs := tripsIxByRoute[route]
 
 	resp := make([]TripResponse, 0, len(tripIxs))
-	for tripIx := range tripIxs {
+	for _, tripIx := range tripIxs {
 		trip := trips[tripIx]
 		tripResponse := TripResponse{
 			TripID:    trip.TripID,
@@ -59,7 +59,7 @@ func buildTripResponse(
 
 		stopTimeIxs := stopTimesIxByTrip[trip.TripID]
 		tripResponse.Schedules = make([]ScheduleResponse, 0, len(stopTimeIxs))
-		for stopTimeIx := range stopTimeIxs {
+		for _, stopTimeIx := range stopTimeIxs {
 			stopTime := stopTimes[stopTimeIx]
 			tripResponse.Schedules = append(tripResponse.Schedules, ScheduleResponse{
 				StopID:    stopTime.StopID,

--- a/trogsit/app.go
+++ b/trogsit/app.go
@@ -46,38 +46,32 @@ func buildTripResponse(
 	trips []*Trip,
 	tripsIxByRoute map[string][]int,
 ) []TripResponse {
-	tripIxs, ok := tripsIxByRoute[route]
+	tripIxs := tripsIxByRoute[route]
 
-	if ok {
-		resp := make([]TripResponse, 0, len(tripIxs))
-		for tripIx := range tripIxs {
-			trip := trips[tripIx]
-			tripResponse := TripResponse{
-				TripID:    trip.TripID,
-				ServiceID: trip.ServiceID,
-				RouteID:   trip.RouteID,
-			}
-
-			stopTimeIxs, ok := stopTimesIxByTrip[trip.TripID]
-			if ok {
-				tripResponse.Schedules = make([]ScheduleResponse, 0, len(stopTimeIxs))
-				for stopTimeIx := range stopTimeIxs {
-					stopTime := stopTimes[stopTimeIx]
-					tripResponse.Schedules = append(tripResponse.Schedules, ScheduleResponse{
-						StopID:    stopTime.StopID,
-						Arrival:   stopTime.Arrival,
-						Departure: stopTime.Departure,
-					})
-				}
-			} else {
-				tripResponse.Schedules = []ScheduleResponse{}
-			}
-			resp = append(resp, tripResponse)
+	resp := make([]TripResponse, 0, len(tripIxs))
+	for tripIx := range tripIxs {
+		trip := trips[tripIx]
+		tripResponse := TripResponse{
+			TripID:    trip.TripID,
+			ServiceID: trip.ServiceID,
+			RouteID:   trip.RouteID,
 		}
-		return resp
-	} else {
-		return []TripResponse{}
+
+		stopTimeIxs := stopTimesIxByTrip[trip.TripID]
+		tripResponse.Schedules = make([]ScheduleResponse, 0, len(stopTimeIxs))
+		for stopTimeIx := range stopTimeIxs {
+			stopTime := stopTimes[stopTimeIx]
+			tripResponse.Schedules = append(tripResponse.Schedules, ScheduleResponse{
+				StopID:    stopTime.StopID,
+				Arrival:   stopTime.Arrival,
+				Departure: stopTime.Departure,
+			})
+		}
+
+		resp = append(resp, tripResponse)
 	}
+
+	return resp
 }
 
 func main() {
@@ -110,12 +104,8 @@ func getStopTimes() ([]*StopTime, map[string][]int) {
 
 	parseCsvFile(filename, headers, func(records []string, i int) {
 		trip := records[0]
-		sts, ok := stsByTrip[trip]
-		if ok {
-			stsByTrip[trip] = append(sts, i)
-		} else {
-			stsByTrip[trip] = []int{i}
-		}
+
+		stsByTrip[trip] = append(stsByTrip[trip], i)
 		stopTimes = append(stopTimes, &StopTime{TripID: trip, StopID: records[3], Arrival: records[1], Departure: records[2]})
 	})
 
@@ -135,12 +125,8 @@ func getTrips() ([]*Trip, map[string][]int) {
 
 	parseCsvFile(filename, headers, func(records []string, i int) {
 		route := records[0]
-		ts, ok := tripsByRoute[route]
-		if ok {
-			tripsByRoute[route] = append(ts, i)
-		} else {
-			tripsByRoute[route] = []int{i}
-		}
+
+		tripsByRoute[route] = append(tripsByRoute[route], i)
 		trips = append(trips, &Trip{TripID: records[2], RouteID: route, ServiceID: records[1]})
 	})
 

--- a/trogsit/app_test.go
+++ b/trogsit/app_test.go
@@ -3,13 +3,13 @@ package main
 import "testing"
 
 func BenchmarkTripResp(b *testing.B) {
-	stopTimes, stopTimesIxByTrip := getStopTimes()
-	trips, tripsIxByRoute := getTrips()
+	_, stopTimesByTrip := getStopTimes()
+	_, tripsIxByRoute := getTrips()
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
 		for _, route := range routes {
-			buildTripResponse(tripsIxByRoute[route], stopTimes, stopTimesIxByTrip, trips)
+			buildTripResponse(tripsIxByRoute[route], stopTimesByTrip)
 		}
 	}
 }

--- a/trogsit/app_test.go
+++ b/trogsit/app_test.go
@@ -1,0 +1,59 @@
+package main
+
+import "testing"
+
+func BenchmarkTripResp(b *testing.B) {
+	stopTimes, stopTimesIxByTrip := getStopTimes()
+	trips, tripsIxByRoute := getTrips()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		for _, route := range routes {
+			buildTripResponse(route, stopTimes, stopTimesIxByTrip, trips, tripsIxByRoute)
+		}
+	}
+}
+
+func BenchmarkGetStopTimes(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		getStopTimes()
+	}
+}
+
+func BenchmarkGetTrips(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		getTrips()
+	}
+}
+
+var routes = []string{
+	"Mattapan",
+	"Orange",
+	"Green-B",
+	"Green-C",
+	"Green-D",
+	"Green-E",
+	"Blue",
+	"741",
+	"742",
+	"743",
+	"751",
+	"749",
+	"746",
+	"CR-Fairmount",
+	"CR-Fitchburg",
+	"CR-Worcester",
+	"CR-Franklin",
+	"CR-Greenbush",
+	"CR-Haverhill",
+	"CR-Kingston",
+	"CR-Lowell",
+	"CR-Middleborough",
+	"CR-Needham",
+	"CR-Newburyport",
+	"CR-Providence",
+	"CR-Foxboro",
+	"Boat-F4",
+	"Boat-F1",
+	"Boat-EastBoston",
+}

--- a/trogsit/app_test.go
+++ b/trogsit/app_test.go
@@ -9,7 +9,7 @@ func BenchmarkTripResp(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		for _, route := range routes {
-			buildTripResponse(route, stopTimes, stopTimesIxByTrip, trips, tripsIxByRoute)
+			buildTripResponse(tripsIxByRoute[route], stopTimes, stopTimesIxByTrip, trips)
 		}
 	}
 }


### PR DESCRIPTION
k6 run -u 50 --duration 30s **loadTest.js**
| lang (_branch_) | http_reqs/sec | http_req_duration avg
|---|---|---|
go (_main_) | 2,156 /s | 22.67 ms
go (_perf_) | 2,924 /s | 16.78 ms
rust (_main_) | 2,310 /s | 21.13 ms

k6 run -u 50 --duration 30s **loadTestSmallResponses.js**
| lang (_branch_) | http_reqs/sec | http_req_duration avg
|---|---|---|
go (_main_) |  7,728 /s |  6.35 ms
go (_perf_) | 16,244 /s | 2.98 ms
rust (_main_) | 13,387 /s |  3.64 ms

csv load times
| filename | go (_main_) | go (_perf_) | rust (_main_) |
|---|---|---|---|
stop_times.txt | 1.15 s | 835 ms | 677 ms
trips.txt | 31 ms | 30 ms | 24 ms