### PR TITLE
Some minor improvements to the scala code

### DIFF
--- a/trala/app/src/MinimalApplication.scala
+++ b/trala/app/src/MinimalApplication.scala
@@ -1,26 +1,31 @@
 package app
 
-import gtfs_data._
+import gtfs_data.*
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+import com.github.plokhotnyuk.jsoniter_scala.macros.*
+import scala.collection.mutable.ArrayBuffer
 
-object MinimalApplication extends cask.MainRoutes {
+object MinimalApplication extends cask.MainRoutes:
   GTFSData // reference it, to trigger the data load
 
   override def port = 4000
 
+  given JsonValueCodec[ArrayBuffer[TripResponse]] = JsonCodecMaker.make
+
   @cask.get("/schedules/:route")
   def schedules(route: String) =
     val schedules = GTFSData.schedulesForRoute(route)
-    upickle.default.write(schedules)
+    cask.Response(
+      writeToString(schedules),
+      headers = Seq("Content-Type" -> "application/json")
+    )
 
   @cask.get("/")
-  def hello() = {
+  def hello() =
     "Hello World!"
-  }
 
   @cask.post("/do-thing")
-  def doThing(request: cask.Request) = {
+  def doThing(request: cask.Request) =
     request.text().reverse
-  }
 
   initialize()
-}

--- a/trala/build.sc
+++ b/trala/build.sc
@@ -4,8 +4,13 @@ object app extends ScalaModule {
   def scalaVersion = "3.2.0"
 
   def ivyDeps = Agg(
-    ivy"com.lihaoyi::cask:0.8.3"
+    ivy"com.lihaoyi::cask:0.8.3",
+    ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core::2.17.6"
   )
+  def compileIvyDeps = Agg(
+    ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros::2.17.6"
+  )
+
   object test extends Tests {
     def testFramework = "utest.runner.Framework"
 


### PR DESCRIPTION
The result is slightly faster parsing and much faster serialization

* close files after reading with `Using.resource`
* stop splitting lines by comma after reaching enough elements
* simplify index-creation by using `getOrElseUpdate`
* scala3-style indentation over curly brackets
* use `+=` over `addOne` as most scala-code tends to do
* avoid double lookup in `schedulesForRoute`, by looping over both the option and its content
* switched from upickle to jsoniter-scala to improve serialization speed
* added application/json content-type