### PR TITLE
ASP.NET minimal API

### DIFF
--- a/TranNetMin/Program.cs
+++ b/TranNetMin/Program.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics;
+using Sylvan.Data.Csv;
+
+var gtfs = new GTFSService();
+
+var app = WebApplication.Create();
+app.MapGet("/", () => $"ASP.NET ({Environment.Version}) minimal transit data API.");
+app.MapGet("/schedules/{routeId}", (string routeId) => gtfs.GetRoute(routeId)?.Trips);
+app.Run();
+
+class Route
+{
+    public Route()
+    {
+        this.Trips = new List<Trip>();
+    }
+
+    public List<Trip> Trips { get; }
+}
+
+record Trip(
+    string trip_id,
+    string route_id,
+    string service_id,
+    List<StopTime> Schedules
+);
+
+record StopTime(
+    string stop_id,
+    string arrival,
+    string departure
+);
+
+class GTFSService
+{
+    readonly Dictionary<string, Route> routes;
+
+    public Route? GetRoute(string route)
+    {
+        return routes.GetValueOrDefault(route);
+    }
+
+    public GTFSService()
+    {
+        this.routes = new Dictionary<string, Route>(StringComparer.OrdinalIgnoreCase);
+        var trips = new Dictionary<string, Trip>();
+
+        using var tripData = CsvDataReader.Create(@"../MBTA_GTFS/trips.txt");
+        while (tripData.Read())
+        {
+            var routeId = tripData.GetString(0);
+            var serviceId = tripData.GetString(1);
+            var tripId = tripData.GetString(2);
+
+            var trip = new Trip(tripId, routeId, serviceId, new List<StopTime>());
+            trips.Add(tripId, trip);
+
+            if (!routes.TryGetValue(routeId, out var route))
+            {
+                route = new Route();
+                routes.Add(routeId, route);
+            }
+            route.Trips.Add(trip);
+        }
+
+        var sw = Stopwatch.StartNew();
+        using var stopData = CsvDataReader.Create(@"../MBTA_GTFS/stop_times.txt");
+        while (stopData.Read())
+        {
+            var tripId = stopData.GetString(0);
+            var arrival = stopData.GetString(1);
+            var departure = stopData.GetString(2);
+            var stopId = stopData.GetString(3);
+
+            var stop = new StopTime(stopId, arrival, departure);
+
+            if (trips.TryGetValue(tripId, out var trip))
+            {
+                trip.Schedules.Add(stop);
+            }
+            else
+            {
+                throw new InvalidDataException();
+            }
+        }
+        sw.Stop();
+        Console.WriteLine($"Loaded stop_times.txt in {sw.ElapsedMilliseconds} ms.");
+    }
+}

--- a/TranNetMin/Properties/launchSettings.json
+++ b/TranNetMin/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:4000"
+    }
+  }
+}

--- a/TranNetMin/TranNetMin.csproj
+++ b/TranNetMin/TranNetMin.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Sylvan.Data.Csv" Version="1.2.4"/>
+	</ItemGroup>
+
+</Project>

--- a/TranNetMin/appsettings.json
+++ b/TranNetMin/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/TranNetMin/readme.md
+++ b/TranNetMin/readme.md
@@ -1,0 +1,16 @@
+﻿# ASP.NET Minimal Transit API
+
+I understand that .NET and C# have a reputation for being excessively verbose, and overwrought compared to other languages. To try to dispell that impression, I wanted to implement a "minimal" ASP.NET/C# API that could also compete with the best alternatives. The entire application is implemented in the Program.cs file, and uses my [Sylvan.Data.Csv](https://github.com/MarkPflug/Sylvan) library for loading the CSV files.
+
+Coincidently, the original rust and C# implementations had the exact same number of lines, when measuring trannet with powershell cmd: `dir *.cs -rec | gc | measure-object`. This minimal implementation is less than half the LOC, without doing anything particularly egregious to achieve that. I reworked the route data structures a bit to make binding the response trivial. These changes might violate the spirit of the comparison, but feel more idiomatic to me.
+
+Here is a comparison of the rust (trustit), original C# (trannet) and the minimal (TranNetMin) implementations, running on my machine, which Windows 10 running on an Intel I7-7700K. I included TranNetMin running on .NET 6, and .NET 7 rc2. Your results will certainly vary.
+
+|Implementation|LOC|CSV Load (ms)|Req/s|
+|-|-|-|
+|Trustit|213|987|844|
+|Trannet|213|1457|649|
+|TranNetMin 6.0|90|498|838|
+|TranNetMin 7.0|90|551|902|
+
+At least on my machine, this minimal ASP.NET implementation beats the current tRUSTit implementation at CSV parsing by a significant margin, and is roughly equivalent (faster on .NET 7) in request throughput.

--- a/TranNetMin/readme.md
+++ b/TranNetMin/readme.md
@@ -7,7 +7,7 @@ Coincidently, the original rust and C# implementations had the exact same number
 Here is a comparison of the rust (trustit), original C# (trannet) and the minimal (TranNetMin) implementations, running on my machine, which Windows 10 running on an Intel I7-7700K. I included TranNetMin running on .NET 6, and .NET 7 rc2. Your results will certainly vary.
 
 |Implementation|LOC|CSV Load (ms)|Req/s|
-|-|-|-|
+| - | - | - | - |
 |Trustit|213|987|844|
 |Trannet|213|1457|649|
 |TranNetMin 6.0|90|498|838|


### PR DESCRIPTION
An ASP.NET (C#) minimal API implementation that beats the current rust implementation (on my machine), with fewer than half the LOC.

|Implementation|LOC|CSV Load (ms)|Req/s|
| - | - | - | - |
|Trustit|213|987|844|
|Trannet|213|1457|649|
|TranNetMin 6.0|90|498|838|
|TranNetMin 7.0|90|551|902|

See readme.md.

I would observe that this competition is a bit silly, because this API only generates 189 unique route responses. The entire app could be statically generated in a couple seconds. Perhaps an API that returns the next time that a bus will arrive at a given route/stop would make it a bit more dynamic, and realistic? As it stands, a client would be better off downloading the source .zip (13mb) data and doing everything client-side (and potentially offline), rather than requesting JSON payloads that might also measure in the multi-megabyte range.